### PR TITLE
porting py2 to 3

### DIFF
--- a/examples/ip_uniqueness.py
+++ b/examples/ip_uniqueness.py
@@ -108,9 +108,9 @@ violations = [(vrf, addr, ifaces) for (vrf, addr),
               ifaces in vrfSubnetToIfaceMap.items() if len(ifaces) > 1]
 
 if not violations:
-    print "OK"
+    print ("OK")
 else:
-    print "Found the following IP uniqueness violations:"
+    print ("Found the following IP uniqueness violations:")
     printTable(
         ["VRF", "Subnet", "Interfaces"],
         [[vrf, formatIpAddr(addr), ", ".join([dn + ':' + s

--- a/examples/mismatched_interfaces.py
+++ b/examples/mismatched_interfaces.py
@@ -57,9 +57,9 @@ violations = [(d, i)
 
 # Report the violations, if any
 if not violations:
-    print "OK"
+    print ("OK")
 else:
-    print "Interfaces with differing admin and operational states"
+    print ("Interfaces with differing admin and operational states")
     printTable(
         ["Device", "Interface", "Admin status", "Oper status"],
         [[d['name'], i['name'], i['adminStatus'], i['operStatus']]

--- a/examples/show_unique_platforms.py
+++ b/examples/show_unique_platforms.py
@@ -65,11 +65,11 @@ for device in platformDataset['devices']:
     models.add((platform['model']))
     vendors.add((platform['vendor']))
 
-print "Number of unique vendor, model, os combinations:", len(platforms)
-print "Number of unique OS versions:", len(osVersions)
-print "Number of unique device models:", len(models)
-print "Number of unique vendors:", len(vendors)
-print ""
+print ("Number of unique vendor, model, os combinations:", len(platforms))
+print ("Number of unique OS versions:", len(osVersions))
+print ("Number of unique device models:", len(models))
+print ("Number of unique vendors:", len(vendors))
+print ("")
 
 printTable(["Vendor", "Model", "Os Version"],
            [list(x) for x in sorted(platforms)])


### PR DESCRIPTION
clean up `print` commands without parentheses in python 2